### PR TITLE
Make extension ractor safe

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ end
 
 # test
 Rake::TestTask.new(:test => :compile) do |t|
-  t.test_files = FileList['test/test.rb']
+  t.test_files = FileList['test/test.rb', 'test/ractor_test.rb']
   t.verbose = true
 end
 

--- a/ext/digest/xxhash/ext.c
+++ b/ext/digest/xxhash/ext.c
@@ -1083,6 +1083,10 @@ void Init_xxhash()
 {
 	#define DEFINE_ID(x) _id_##x = rb_intern_const(#x);
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	DEFINE_ID(digest)
 	DEFINE_ID(finish)
 	DEFINE_ID(hexdigest)

--- a/test/ractor_test.rb
+++ b/test/ractor_test.rb
@@ -1,0 +1,7 @@
+if defined?(Ractor)
+  describe 'xxhash inside ractor' do
+    it 'calculates inside ractor' do
+      assert_equal(Ractor.new { Digest::XXH32.hexdigest('hello') }.take, 'fb0077f9')
+    end
+  end
+end


### PR DESCRIPTION
I looked up the code how the ruby `Digest` module was made "ractor safe" and applied it to this module. 
